### PR TITLE
Update HtmlLocalLinkParser.cs

### DIFF
--- a/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
+++ b/src/Umbraco.Core/Templates/HtmlLocalLinkParser.cs
@@ -16,6 +16,11 @@ public sealed class HtmlLocalLinkParser
     internal static readonly Regex LocalLinkTagPattern = new(
         @"<a\s+(?:(?:(?:type=['""](?<type>document|media)['""].*?(?<locallink>href=[""']/{localLink:(?<guid>[a-fA-F0-9-]+)})[""'])|((?<locallink>href=[""']/{localLink:(?<guid>[a-fA-F0-9-]+)})[""'].*?type=(['""])(?<type>document|media)(?:['""])))|(?:(?:type=['""](?<type>document|media)['""])|(?:(?<locallink>href=[""']/{localLink:[a-fA-F0-9-]+})[""'])))[^>]*>",
         RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
+    
+    // used same from v15 as the LocalLinkTagPattern is failing on the current version
+    internal static readonly Regex LocalLinkPatternNew = new(
+        @"<a.+?href=['""](?<locallink>\/?{localLink:(?<guid>[a-fA-F0-9-]+)})[^>]*?>",
+        RegexOptions.IgnoreCase | RegexOptions.IgnorePatternWhitespace);
 
     internal static readonly Regex LocalLinkPattern = new(
         @"href=""[/]?(?:\{|\%7B)localLink:([a-zA-Z0-9-://]+)(?:\}|\%7D)",
@@ -116,7 +121,7 @@ public sealed class HtmlLocalLinkParser
 
     private IEnumerable<LocalLinkTag> FindLocalLinkIds(string text)
     {
-        MatchCollection localLinkTagMatches = LocalLinkTagPattern.Matches(text);
+        MatchCollection localLinkTagMatches = LocalLinkPatternNew.Matches(text);
         foreach (Match linkTag in localLinkTagMatches)
         {
             if (linkTag.Groups.Count < 1)


### PR DESCRIPTION
LocalLinkTagPattern regex was failing and updated to the latest one the same as v15.

### Prerequisites

- [x] I have added steps to test this contribution in the description below

If there's an existing issue for this PR then this fixes: [Issue](https://github.com/umbraco/Umbraco-CMS/issues/17464)

### Description

Added a new regex pattern (LocalLinkPatternNew) in HtmlLocalLinkParser, LocalLinkPatternNew is the same as v15.

The previous regex pattern (LocalLinkTagPattern) was failing inside RTE as mentioned in the issue above or the [forum](https://our.umbraco.com/forum/using-umbraco-and-getting-started/114928-umbraco-14-rich-text-editor-link-error) 

Issue in hindsight is that the failing of regex results in the rendering of links in RTE as something like this 
href="/{localLink:dff7c2bc-4fb8-4fd1-af78-c826124cf0dc}"

Verified the new regex pattern in the Regex101 or inside VS while debugging.

steps to test : 

_RTE content_
"<p><a rel=\"noopener\" type=\"document\" href=\"/{localLink:dff7c2bc-4fb8-4fd1-af78-c826124cf0dc}\" target=\"_blank\" title=\"dasdasdsa\">dasdasdsa&nbsp; &nbsp;d</a></p>\n<p>&nbsp;</p>\n<p><a rel=\"noopener\" type=\"document\" href=\"/{localLink:dff7c2bc-4fb8-4fd1-af78-c826124cf0dc}\" target=\"_blank\" title=\"test\">test</a></p>"

1. Testing the current regex LocalLinkTagPattern with the above text
2. Do the same with the LocalLinkPatternNew regex

<!-- Thanks for contributing to Umbraco CMS! -->
